### PR TITLE
Improve descriptions, help texts, error messages, etc

### DIFF
--- a/shuup_rest_api/views/category.py
+++ b/shuup_rest_api/views/category.py
@@ -46,7 +46,7 @@ class CategorySerializer(TranslatableModelSerializer):
             data["image"] = filer_image_from_upload(
                 self.context["request"], path=data["image_path"], upload_data=data["image"])
         elif data.get("image"):
-            raise serializers.ValidationError("Path is required when sending a Category image.")
+            raise serializers.ValidationError("Error! Path is required when sending a Category image.")
         return data
 
     def get_image(self, category):

--- a/shuup_rest_api/views/front_passwords.py
+++ b/shuup_rest_api/views/front_passwords.py
@@ -27,7 +27,7 @@ class SetPasswordSerializer(serializers.Serializer):
         user_model = get_user_model()
 
         if password1 != password2:
-            raise serializers.ValidationError("Passwords do not match")
+            raise serializers.ValidationError("Error! Passwords do not match.")
 
         try:
             uid = urlsafe_base64_decode(uidb64)
@@ -36,7 +36,7 @@ class SetPasswordSerializer(serializers.Serializer):
             user = None
 
         if not user or not default_token_generator.check_token(user, token):
-            raise serializers.ValidationError("The recovery link is invalid.")
+            raise serializers.ValidationError("Error! The recovery link is invalid.")
         data["user"] = user
         return data
 
@@ -56,11 +56,11 @@ class SetAuthenticatedUserPasswordSerializer(serializers.Serializer):
         password1 = data.get("new_password1")
         password2 = data.get("new_password2")
         if password1 != password2:
-            raise serializers.ValidationError("Passwords do not match")
+            raise serializers.ValidationError("Error! Passwords do not match.")
         password = data.get("password")
         user = self.context["request"].user
         if not user or not user.check_password(password):
-            raise serializers.ValidationError("Invalid password")
+            raise serializers.ValidationError("Error! Invalid password.")
         return data
 
     def save(self):

--- a/shuup_rest_api/views/front_products.py
+++ b/shuup_rest_api/views/front_products.py
@@ -35,8 +35,8 @@ def make_comma_separated_list_fiter(filter_name, field_expression):
     """
     Create a filter which uses a comma-separated list of values to filter the queryset.
 
-    :param str filter_name: the name of the query param to fetch values
-    :param str field_expression: the field expression to filter the queryset, like `categories__in`
+    :param str filter_name: the name of the query param to fetch values.
+    :param str field_expression: the field expression to filter the queryset, like `categories__in`.
     """
     def filter_queryset(instance, request, queryset, view):
         values = request.query_params.get(filter_name)
@@ -394,7 +394,7 @@ class FrontShopProductFilter(filters.BaseFilterBackend):
     """
     Filter shop products by visible or listed products and not deleted ones.
     You can also filter by:
-        - shop - the ID of the shop
+        - shop - the ID of the shop.
     """
     def filter_queryset(self, request, queryset, view):
         shop = request.query_params.get("shop")
@@ -543,8 +543,8 @@ class ProductSerializer(serializers.ModelSerializer):
 
 class ClosestShopFilter(filters.BaseFilterBackend):
     """
-    Add a field using subquery to get the closest shop distance
-    Based of `shuup_rest_api.views.shop.NearbyShopsFilter`
+    Add a field using subquery to get the closest shop distance.
+    Based on `shuup_rest_api.views.shop.NearbyShopsFilter`.
     """
     def filter_queryset(self, request, queryset, view):
         latitude = float(request.query_params.get("lat", 0))

--- a/shuup_rest_api/views/front_users.py
+++ b/shuup_rest_api/views/front_users.py
@@ -40,7 +40,7 @@ class UserRegisterSerializer(serializers.ModelSerializer):
     def validate(self, data):
         user_model = get_user_model()
         if not data.get(user_model.USERNAME_FIELD) and not data.get("email"):
-            raise serializers.ValidationError("username and/or email is required")
+            raise serializers.ValidationError("Error! Username and/or email is required.")
         if user_model.USERNAME_FIELD not in data and user_model.USERNAME_FIELD != "email":
             email = data.get("email")
             if email:
@@ -48,7 +48,7 @@ class UserRegisterSerializer(serializers.ModelSerializer):
 
         pwd = data.pop("password")
         if user_model.objects.filter(**data).exists():
-            raise serializers.ValidationError("User already exists.")
+            raise serializers.ValidationError("Error! User already exists.")
         data["password"] = pwd
         return data
 
@@ -97,7 +97,7 @@ class ContactSerializer(serializers.ModelSerializer):
 
 class FrontUserViewSet(PermissionHelperMixin, CreateModelMixin, UpdateModelMixin, RetrieveModelMixin, GenericViewSet):
     """
-    register: Register user
+    register: Register a user.
 
     retrieve: Fetches the current contact.
 
@@ -132,6 +132,7 @@ class FrontUserViewSet(PermissionHelperMixin, CreateModelMixin, UpdateModelMixin
     def create(self, request, *args, **kwargs):
         """
         Register a User.
+
         If the user information already exists, an error will be returned.
         """
         serializer = UserRegisterSerializer(data=request.data)

--- a/shuup_rest_api/views/manufacturer.py
+++ b/shuup_rest_api/views/manufacturer.py
@@ -40,7 +40,7 @@ class ManufacturerSerializer(serializers.ModelSerializer):
             data["logo"] = filer_image_from_upload(
                 self.context["request"], path=data["logo_path"], upload_data=data["logo"])
         elif data.get("logo"):
-            raise serializers.ValidationError("Path is required when sending a manufacturer logo.")
+            raise serializers.ValidationError("Error! Path is required when sending a manufacturer logo.")
         return data
 
     def get_logo(self, manufacturer):

--- a/shuup_rest_api/views/orders.py
+++ b/shuup_rest_api/views/orders.py
@@ -123,7 +123,7 @@ class OrderTaxesMixin(object):
     @detail_route(methods=['get'])
     def taxes(self, request, pk=None):
         """
-        Get taxes for order
+        Get taxes for order.
         """
         from shuup_rest_api.views.tax import OrderLineTaxSerializer, TaxSummarySerializer
         order = self.get_object()
@@ -269,7 +269,7 @@ class OrderViewSet(PermissionHelperMixin,
         """ Set the order as Fully Paid. """
         order = self.get_object()
         if order.is_paid():
-            return Response({"error": _("Order is already fully paid")})
+            return Response({"error": _("Order is already fully paid.")})
 
         request.data["currency"] = order.currency
         request.data["amount_value"] = (order.taxful_total_price_value - order.get_total_paid_amount().value)
@@ -286,4 +286,4 @@ def _handle_payment_creation(request, order):
         data["payment_identifier"],
         data.get("description", "")
     )
-    return Response({"success": _("Payment created")}, status=status.HTTP_201_CREATED)
+    return Response({"success": _("Payment was created.")}, status=status.HTTP_201_CREATED)

--- a/shuup_rest_api/views/product_media.py
+++ b/shuup_rest_api/views/product_media.py
@@ -44,12 +44,12 @@ class ProductMediaUploadSerializer(ProductMediaSerializer):
 
     def validate(self, data):
         if not (data.get("file") or data.get("external_url")):
-            raise serializers.ValidationError("You may set either `file` or `external_url`.")
+            raise serializers.ValidationError("Error! You may set either `file` or `external_url`.")
         elif data.get("file"):
             if not data.get("path"):
-                raise serializers.ValidationError("`path` is required when `file` is set.")
+                raise serializers.ValidationError("Error! `path` is required when `file` is set.")
             elif not data["file"].content_type.startswith("image/") and data["kind"] != ProductMediaKind.IMAGE:
-                raise serializers.ValidationError("Kind must be IMAGE for this content type.")
+                raise serializers.ValidationError("Error! `Kind` must be `ProductMediaKind.IMAGE` for this content type.")
 
             # changes the filer function according to the media type
             filer_func = filer_image_from_upload if data["kind"] == ProductMediaKind.IMAGE else filer_file_from_upload
@@ -88,7 +88,7 @@ class ProductMediaViewSet(PermissionHelperMixin,
     serializer_class = ProductMediaSerializer
 
     def get_serializer_class(self):
-        """ The serializer for upload must be the ProductMediaUploadSerializer """
+        """ The serializer for upload must be the ProductMediaUploadSerializer. """
         if self.request.method == "PUT":
             return ProductMediaUploadSerializer
         return super(ProductMediaViewSet, self).get_serializer_class()

--- a/shuup_rest_api/views/product_variation.py
+++ b/shuup_rest_api/views/product_variation.py
@@ -34,7 +34,7 @@ class ProductLinkVariationVariableSerializer(serializers.Serializer):
 
     def validate(self, data):
         if self.context["request"].method in ("PUT", "POST") and not data.get("product"):
-            raise serializers.ValidationError("`product` is required for this method.")
+            raise serializers.ValidationError("Error! `product` is required for this method.")
         return data
 
 

--- a/shuup_rest_api/views/products.py
+++ b/shuup_rest_api/views/products.py
@@ -101,7 +101,7 @@ class ProductPackageChildSerializer(serializers.Serializer):
 
 
 class ShopProductSubsetSerializer(ShopProductSerializer):
-    """ A subset class to hide id and product fields """
+    """ A subset class to hide id and product fields. """
     class Meta:
         model = ShopProduct
         extra_kwargs = {
@@ -353,7 +353,7 @@ class ProductViewSet(ProtectedModelViewSetMixin, PermissionHelperMixin, viewsets
         if serializer.is_valid():
             # attribute does not belong to the product type
             if not product.type.attributes.filter(id=serializer.validated_data["attribute"].pk).exists():
-                return Response({"error": "Attribute does not belong to the product type."},
+                return Response({"error": "Error! Attribute does not belong to the product type."},
                                 status=status.HTTP_400_BAD_REQUEST)
 
             serializer.save(product=product)
@@ -450,7 +450,7 @@ class ProductViewSet(ProtectedModelViewSetMixin, PermissionHelperMixin, viewsets
                     result = ProductVariationResult.objects.get(product=product,
                                                                 combination_hash=serializer.validated_data["hash"])
                 except ProductVariationResult.DoesNotExist:
-                    return Response(data={"error": "Combination not found"}, status=status.HTTP_404_NOT_FOUND)
+                    return Response(data={"error": "Error! Combination not found."}, status=status.HTTP_404_NOT_FOUND)
 
                 if serializer.validated_data.get("status"):
                     result.status = serializer.validated_data["status"]
@@ -464,7 +464,7 @@ class ProductViewSet(ProtectedModelViewSetMixin, PermissionHelperMixin, viewsets
                     result = ProductVariationResult.objects.get(product=product,
                                                                 combination_hash=serializer.validated_data["hash"])
                 except ProductVariationResult.DoesNotExist:
-                    return Response(data={"error": "Combination not found"}, status=status.HTTP_404_NOT_FOUND)
+                    return Response(data={"error": "Error! Combination not found."}, status=status.HTTP_404_NOT_FOUND)
 
                 result.delete()
                 product.verify_mode()

--- a/shuup_rest_api/views/refunds.py
+++ b/shuup_rest_api/views/refunds.py
@@ -41,7 +41,7 @@ class RefundMixin(object):
 
         if not order.can_create_refund():
             return Response(
-                {"error": _("Order can not be refunded at the moment.")}, status=status.HTTP_400_BAD_REQUEST)
+                {"error": _("Order can't be refunded at the moment.")}, status=status.HTTP_400_BAD_REQUEST)
 
         serializer = PartialRefundSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -51,7 +51,7 @@ class RefundMixin(object):
         for refund_line_data in data["refund_lines"]:
             line = refund_line_data["line"]
             if line.order.id != order.id or line.type == OrderLineType.REFUND:
-                return Response({"error": _("Can not refund line.")}, status=status.HTTP_400_BAD_REQUEST)
+                return Response({"error": _("Can't refund the line.")}, status=status.HTTP_400_BAD_REQUEST)
 
             refund_data.append({
                 "line": line,
@@ -77,7 +77,7 @@ class RefundMixin(object):
 
         if not order.can_create_refund():
             return Response(
-                {"error": _("Order can not be refunded at the moment.")}, status=status.HTTP_400_BAD_REQUEST)
+                {"error": _("Order can't be refunded at the moment.")}, status=status.HTTP_400_BAD_REQUEST)
 
         serializer = FullRefundSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/shuup_rest_api/views/suppliers.py
+++ b/shuup_rest_api/views/suppliers.py
@@ -100,7 +100,7 @@ class SupplierViewSet(SearchableMixin, PermissionHelperMixin, ProtectedModelView
                 created_by=request.user
             )
         except NotImplementedError:
-            raise serializers.ValidationError("This supplier does not support stock adjustments")
+            raise serializers.ValidationError("Error! This supplier does not support stock adjustments.")
         status = supplier.get_stock_status(serializer.validated_data["product"].id)
         return Response(ProductStockStatusSerializer(status).data)
 
@@ -118,7 +118,7 @@ class SupplierViewSet(SearchableMixin, PermissionHelperMixin, ProtectedModelView
         try:
             supplier.update_stocks(product_ids)
         except NotImplementedError:
-            raise serializers.ValidationError("This supplier does not support stock updates")
+            raise serializers.ValidationError("Error! This supplier does not support stock updates.")
         return Response()
 
     @schema_serializer_class(SupplierProductsSerialzier)

--- a/shuup_rest_api_tests/test_basket_api.py
+++ b/shuup_rest_api_tests/test_basket_api.py
@@ -804,9 +804,13 @@ def get_user(username, email, password="test"):
 @pytest.mark.django_db
 def test_permissions(admin_user):
     """
-     ainoastaan kaupan staff / customer / objektin omistava user
-     * voi vaihtaa tilauksen tilan, toisen kaupan staff ei voi vaihtaa tilauksen tilaa
-     * retrievaa baskettia kuin sinä itse,
+    Only:
+    1. shop's staff
+    2. customer
+    3. user, who owns the object
+    , can:
+    1. change the status of the order (only the current shop's staff)
+    2. retrieve the basket
     """
 
     set_configuration()
@@ -1162,7 +1166,7 @@ def test_create_with_customer(admin_user, user_mode):
         customer.members.add(get_person_contact(user))
 
     else:
-        raise Exception("It should never enter here!")
+        raise Exception("Error! `user_mode` is of unknown type.")
 
     client = get_client(user)
 
@@ -1201,7 +1205,7 @@ def test_set_customer(admin_user, user_mode):
         user = factories.create_random_user()
 
     else:
-        raise Exception("It should never enter here!")
+        raise Exception("Error! `user_mode` is of unknown type.")
 
     client = get_client(user)
 
@@ -1288,7 +1292,7 @@ def test_set_company_customer(admin_user):
 def test_set_customer_group_prices(admin_user):
     """
     Set the customer to the basket and prices should change
-    accordingly to the customer group
+    accordingly to the customer group.
     """
     set_configuration()
 
@@ -1360,7 +1364,7 @@ def test_set_customer_group_prices(admin_user):
 def test_set_customer_campaigns(admin_user):
     """
     Set the customer to the basket and prices should change
-    accordingly to the rules
+    accordingly to the rules.
     """
     set_configuration()
 
@@ -1447,7 +1451,7 @@ def test_set_customer_campaigns(admin_user):
 @pytest.mark.django_db
 def test_anonymous(admin_user, with_admin):
     """
-    Create order with anonymous user
+    Create order with an anonymous user.
     """
     set_configuration()
 


### PR DESCRIPTION
This is part of a big update to improve various texts in Shuup.

A lot of changes, touching almost every individual Shuup project's repo.

There are too many changes to try to describe them separately, but the 
main ones are:
1. Improve `help_text` descriptions. Fix typos, rewrite and change, 
write new ones.
2. Change some of the model field names (for example rename 
`available_from` -> `available_since`; `available_to` `available_until` 
- this is in a separate commit).
3. Improve some of the documentation.
4. Improve some in-code-comments.
5. Improve `settings.py` files. It's now clearer what each option does.
6. Change some of the naming.
7. Change the error/message system.

The main Shuup repo's Merge Request is here: 
https://github.com/shuup/shuup/pull/2113 (with a reasoning behind 
changes).