### PR TITLE
Fix country code field in AddressSerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Enter here all the changes made to the development version
 
+### Fixed
+
+- Use CountryFieldMixin from django_countries.serializers to handle address country field serialization
+
 ### [2.0.0] - 2020-08-06
 
 ## Added

--- a/shuup_rest_api/views/address.py
+++ b/shuup_rest_api/views/address.py
@@ -9,13 +9,14 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
+from django_countries.serializers import CountryFieldMixin
 from rest_framework import mixins, serializers
 from rest_framework.viewsets import GenericViewSet
 from shuup.core.models import MutableAddress
 from shuup_api.mixins import PermissionHelperMixin, ProtectedModelViewSetMixin
 
 
-class AddressSerializer(serializers.ModelSerializer):
+class AddressSerializer(CountryFieldMixin, serializers.ModelSerializer):
     class Meta:
         model = MutableAddress
         fields = "__all__"


### PR DESCRIPTION
### Fixed

- Use ReadOnlyField to render `code` property of `MutableAddress.country` to prevent breaks when country is blank